### PR TITLE
Define the VirtualBox VM name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,7 @@ Vagrant.configure('2') do |config|
 
       n.vm.provider 'virtualbox' do |v|
         v.customize ['modifyvm', :id, '--ioapic', 'on']
+        v.customize ['modifyvm', :id, '--name', "#{node}.#{domain}" ]
         v.memory = memory
         v.cpus = cpus
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ Vagrant.configure('2') do |config|
 
       n.vm.provider 'virtualbox' do |v|
         v.customize ['modifyvm', :id, '--ioapic', 'on']
-        v.customize ['modifyvm', :id, '--name', "#{node}.#{domain}" ]
+        v.customize ['modifyvm', :id, '--name', "#{node}.#{domain}"]
         v.memory = memory
         v.cpus = cpus
       end


### PR DESCRIPTION
This patch sets the VirtualBox VM name as the FQDN so it is easy to identify it.