### PR TITLE
Enable SLES 12 agent versioning

### DIFF
--- a/puppet-agent-installer.sh
+++ b/puppet-agent-installer.sh
@@ -79,6 +79,24 @@ detect_debian_8 ( ) {
 
 }
 
+
+detect_sles_12 ( ) {
+
+  if egrep 'VERSION_ID="12' /etc/os-release &> /dev/null; then
+    # Remove an inacessible remote repository
+    zypper removerepo sles12-dvd1
+    # Remove a repository with incorrect URL
+    zypper removerepo devel_tools_scm
+    # Enable GPG check for the Puppet repositories
+    zypper modifyrepo -g puppetlabs-pc1 puppetlabs-pc1-source
+    # Update Puppet metadata to ensure the latest packages
+    zypper refresh puppetlabs-pc1
+    zypper install --oldpackage --no-recommends --no-confirm "puppet-agent=${PUPPET_AGENT_VERSION}"
+  fi
+
+}
+
+detect_sles_12
 detect_rhel_6
 detect_rhel_7
 detect_ubuntu_1604


### PR DESCRIPTION
With this patch SLES 12 VMs could upgrade (or downgrade) puppet-agent version, respecting the PUPPET_AGENT_VERSION parameter.

External Zypper repositories unreachable or with incorrect URLs are removed, as well.