### PR TITLE
Automate Windows Puppet agent installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+dist: trusty
+sudo: required
 rvm:
   - 2.2
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ script:
   - "bundle exec rake rubocop"
   - "bundle exec rake yamllint"
   - "bundle exec rake shellcheck"
+  - "bundle exec rake powershellanalyzer"
 addons:
   apt:
     sources:
       - debian-sid
+      - sourceline: "deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main"
+        key_url: "https://packages.microsoft.com/keys/microsoft.asc"
     packages:
       - shellcheck
+      - powershell

--- a/README.md
+++ b/README.md
@@ -76,6 +76,5 @@ This choice helps us greatly reduce the risk of developing code that might fail 
 
 * Document our workflow
 * Instructions on how to configure text editor, tests, etc.
-* PowerShell script to install puppet-agent on Windows boxes
 * Use a local yaml file to avoid changing `environment.yaml`
 * Minimalistic Puppet module to configure Puppet Server

--- a/Rakefile
+++ b/Rakefile
@@ -31,3 +31,9 @@ task :shellcheck do
   system('shellcheck puppet-agent-installer.sh')
   raise 'Violations found using ShellCheck' unless $CHILD_STATUS.success?
 end
+
+desc 'Validate powershell script installer'
+task :powershellanalyzer do
+  system("powershell -Command 'Invoke-ScriptAnalyzer -Path puppet-agent-installer.ps1'")
+  raise 'Violations found using PowerShell analyzer' unless $CHILD_STATUS.success?
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,8 +51,13 @@ Vagrant.configure('2') do |config|
 
       if data.key?('type') && data['type'] == 'windows'
         n.vm.hostname = node
+        n.vm.communicator = 'winrm'
         n.vm.synced_folder '.', '/vagrant', disabled: true
         n.vm.network 'forwarded_port', host: 3389, guest: 3389, auto_correct: true
+        n.vm.provision 'shell' do |s|
+          s.path = 'puppet-agent-installer.ps1'
+          s.args = ['-PuppetVersion', puppet_agent_version]
+        end
       else
         n.vm.hostname = "#{node}.#{domain}"
         n.vm.synced_folder '.', '/vagrant', type: synced_folder_type

--- a/puppet-agent-installer.ps1
+++ b/puppet-agent-installer.ps1
@@ -1,0 +1,70 @@
+<#
+Originally developed by Hashicorp.
+Source: https://raw.githubusercontent.com/hashicorp/puppet-bootstrap/master/windows.ps1
+
+.SYNOPSIS
+    Installs Puppet on this machine.
+
+.DESCRIPTION
+    Downloads and installs the PuppetLabs Puppet MSI package.
+
+    This script requires administrative privileges.
+
+    You can run this script from an old-style cmd.exe prompt using the
+    following:
+
+      powershell.exe -ExecutionPolicy Unrestricted -NoLogo -NoProfile -Command "& '.\windows.ps1'"
+
+.PARAMETER MsiUrl
+    This is the URL to the Puppet MSI file you want to install. This defaults
+    to a version from PuppetLabs.
+
+.PARAMETER PuppetVersion
+    This is the version of Puppet that you want to install. If you pass this it will override the version in the MsiUrl.
+    This defaults to $null.
+#>
+param(
+   [string]$MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-x64-latest.msi"
+  ,[string]$PuppetVersion = $null
+)
+
+if ($PuppetVersion) {
+  $MsiUrl = "https://downloads.puppetlabs.com/windows/puppet-agent-$($PuppetVersion)-x64.msi"
+  Write-Output "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
+}
+
+$PuppetInstalled = $false
+try {
+  $ErrorActionPreference = "Stop";
+  Get-Command puppet | Out-Null
+  $PuppetInstalled = $true
+  $PuppetVersion=&puppet "--version"
+  Write-Output "Puppet $PuppetVersion is installed. This process does not ensure the exact version or at least version specified, but only that puppet is installed. Exiting..."
+  Exit 0
+} catch {
+  Write-Output "Puppet is not installed, continuing..."
+}
+
+if (!($PuppetInstalled)) {
+  $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+  if (! ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+    Write-Output -ForegroundColor Red "You must run this script as an administrator."
+    Exit 1
+  }
+
+  # Install it - msiexec will download from the url
+  $install_args = @("/qn", "/norestart","/i", $MsiUrl)
+  Write-Output "Installing Puppet. Running msiexec.exe $install_args"
+  $process = Start-Process -FilePath msiexec.exe -ArgumentList $install_args -Wait -PassThru
+  if ($process.ExitCode -ne 0) {
+    Write-Output "Installer failed."
+    Exit 1
+  }
+
+  # Stop the service that it autostarts
+  Write-Output "Stopping Puppet service that is running by default..."
+  Start-Sleep -s 5
+  Stop-Service -Name puppet
+
+  Write-Output "Puppet successfully installed."
+}


### PR DESCRIPTION
This patch provides Windows 2008 R2 and 2012 R2 capability to provision the Puppet AIO agent after boot.

The Puppet agent version is the same from the environment.yaml config file.

The PowerShell script is analyzed for lint correction, and TravisCI is configured to install and execute this task.

This PR addresses issue #11.