### PR TITLE
Adds Debian 9 support

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -23,6 +23,8 @@ nodes:
     box: ubuntu/precise64
   debian-8:
     box: debian/jessie64
+  debian-9:
+    box: debian/stretch64
   sles-11:
     box: elastic/sles-11-x86_64
   sles-12:

--- a/puppet-agent-installer.sh
+++ b/puppet-agent-installer.sh
@@ -79,6 +79,19 @@ detect_debian_8 ( ) {
 
 }
 
+detect_debian_9 ( ) {
+
+  if egrep '^9\.[0-9]' /etc/debian_version &> /dev/null; then
+    cd /tmp
+    wget http://apt.puppetlabs.com/puppetlabs-release-pc1-stretch.deb
+    dpkg -i puppetlabs-release-pc1-stretch.deb
+    rm puppetlabs-release-pc1-stretch.deb
+    apt-get update
+    apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
+  fi
+
+}
+
 detect_sles_12 ( ) {
 
   if egrep 'VERSION_ID="12' /etc/os-release &> /dev/null; then
@@ -113,5 +126,6 @@ detect_ubuntu_1604
 detect_ubuntu_1404
 detect_ubuntu_1204
 detect_debian_8
+detect_debian_9
 detect_sles_11
 detect_sles_12


### PR DESCRIPTION
This patch adds Debian 9 Stretch support. Consider that only Puppet agent 1.10.6 is available for this distro.