### PR TITLE
Add support to Oracle Linux 6 and 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The virtual machine will have the puppet-agent package installed and ready to go
 
 All configuration is loaded from `environment.yaml` file. There are two main keys: `defaults` and `nodes`.
 
-```
+```yaml
 ---
 defaults:
   memory: 1024
@@ -69,6 +69,12 @@ nodes:
     cpus: 2
     type: windows
     box: opentable/win-2008r2-standard-amd64-nocm
+  oracle-7:
+    box: oracle/7
+    box_url: http://yum.oracle.com/boxes/oraclelinux/ol74/ol74.box
+  oracle-6:
+    box: oracle/6
+    box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box
 ```
 
 The `defaults` hash has keys that configure how VirtualBox and Vagrant will work and also values that configure the VMs specified in the `nodes` hash.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,9 @@ Vagrant.configure('2') do |config|
       end
 
       n.vm.box = data['box']
+      if data.key?('box_url')
+        n.vm.box_url = data['box_url']
+      end
       n.vm.network :private_network, ip: "#{network_prefix}.#{index + 100}"
 
       if data.key?('type') && data['type'] == 'windows'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,9 +60,7 @@ Vagrant.configure('2') do |config|
       end
 
       n.vm.box = data['box']
-      if data.key?('box_url')
-        n.vm.box_url = data['box_url']
-      end
+      n.vm.box_url = data['box_url'] if data.key?('box_url')
       n.vm.network :private_network, ip: "#{network_prefix}.#{index + 100}"
 
       if data.key?('type') && data['type'] == 'windows'

--- a/environment.yaml
+++ b/environment.yaml
@@ -47,3 +47,9 @@ nodes:
     cpus: 2
     type: windows
     box: opentable/win-2008r2-standard-amd64-nocm
+  oracle-7:
+    box: oracle/7
+    box_url: http://yum.oracle.com/boxes/oraclelinux/ol74/ol74.box
+  oracle-6:
+    box: oracle/6
+    box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box

--- a/puppet-agent-installer.sh
+++ b/puppet-agent-installer.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 PUPPET_AGENT_VERSION=$1
 
-detect_rhel_7 ( ) {
+detect_rhel_or_oracle_7 ( ) {
 
   if grep -E ' 7\.' /etc/redhat-release &> /dev/null; then
     yum install -y https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
@@ -15,7 +15,7 @@ detect_rhel_7 ( ) {
 
 }
 
-detect_rhel_6 ( ) {
+detect_rhel_or_oracle_6 ( ) {
 
   if grep -E ' 6\.' /etc/redhat-release &> /dev/null; then
     yum install -y https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
@@ -157,8 +157,8 @@ detect_sles_11 ( ) {
 }
 
 detect_rhel_5
-detect_rhel_6
-detect_rhel_7
+detect_rhel_or_oracle_6
+detect_rhel_or_oracle_7
 detect_ubuntu_1604
 detect_ubuntu_1404
 detect_ubuntu_1204


### PR DESCRIPTION
This changes add support to Oracle Linux 6 and 7 releases.

It was necessary to allow the box URL parameter to be setted because
the base boxes are not available in the default Vagrant repository.