### PR TITLE
Add support to Oracle Linux 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ nodes:
   oracle-6:
     box: oracle/6
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box
+  oracle-5:
+    box: gutocarvalho/oracle5x64nocm
 ```
 
 The `defaults` hash has keys that configure how VirtualBox and Vagrant will work and also values that configure the VMs specified in the `nodes` hash.

--- a/environment.yaml
+++ b/environment.yaml
@@ -53,3 +53,5 @@ nodes:
   oracle-6:
     box: oracle/6
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box
+  oracle-5:
+    box: gutocarvalho/oracle5x64nocm

--- a/puppet-agent-installer.sh
+++ b/puppet-agent-installer.sh
@@ -24,16 +24,17 @@ detect_rhel_or_oracle_6 ( ) {
 
 }
 
-detect_rhel_5 ( ) {
+detect_rhel_or_oracle_5 ( ) {
 
   if grep -E ' 5\.' /etc/redhat-release &> /dev/null; then
-    echo 'nameserver 8.8.8.8' > /etc/resolv.conf
     cd /tmp
-    curl -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
-    rpm --import RPM-GPG-KEY-puppet
-    curl -O http://yum.puppetlabs.com/puppetlabs-release-pc1-el-5.noarch.rpm
-    yum install -y puppetlabs-release-pc1-el-5.noarch.rpm
-    yum install -y "puppet-agent-${PUPPET_AGENT_VERSION}"
+    curl -s -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet \
+      && rpm --import RPM-GPG-KEY-puppet \
+      && rm -f RPM-GPG-KEY-puppet \
+      && curl -s -O http://yum.puppetlabs.com/puppetlabs-release-pc1-el-5.noarch.rpm \
+      && yum install -y puppetlabs-release-pc1-el-5.noarch.rpm \
+      && rm -f puppetlabs-release-pc1-el-5.noarch.rpm \
+      && yum install -y "puppet-agent-${PUPPET_AGENT_VERSION}"
   fi
 
 }
@@ -156,7 +157,7 @@ detect_sles_11 ( ) {
 
 }
 
-detect_rhel_5
+detect_rhel_or_oracle_5
 detect_rhel_or_oracle_6
 detect_rhel_or_oracle_7
 detect_ubuntu_1604


### PR DESCRIPTION
This change adds support to Oracle Linux 5. A new Vagrant box is declared in the available list, and the Puppet agent install script is updated to support this distribution.

The issue #36 impacts this change, because CentOS 5 is no more usable without a fix.