### PR TITLE
Add pre-puppet provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ It is very opinionated and based on our workflow, although it should be very use
 
 The virtual machine will have the puppet-agent package installed and ready to go.
 
+## 10-min Puppet Server start
+
+1. Make sure VirtualBox and Vagrant are installed
+1. Clone the project repository
+1. Edit `environment.yaml` to your needs if needed
+1. Copy `scripts/puppet.sh.sample` to `scripts/puppet.sh` and edit it to config the controlrepo name and Puppet Server role
+1. Run `vagrant up puppet`
+
+The virtual machine will have the Puppet Server installed and configured, ready to configure the clients VMs.
+
 ## Configuration
 
 All configuration is loaded from `environment.yaml` file. There are two main keys: `defaults` and `nodes`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -79,6 +79,11 @@ Vagrant.configure('2') do |config|
           s.path = 'puppet-agent-installer.sh'
           s.args = puppet_agent_version
         end
+        if File.exist?("#{vagrant_root}/scripts/#{node}.sh")
+          n.vm.provision 'shell' do |s|
+            s.path = "#{vagrant_root}/scripts/#{node}.sh"
+          end
+        end
       end
     end
   end

--- a/scripts/puppet.sh.sample
+++ b/scripts/puppet.sh.sample
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+##############################################
+# This script configs the Puppet Server localy
+#
+# Change this variables if you want it to
+# provision automatically your server
+
+# The name of your controlrepo project
+CONTROL_REPO=''
+
+# The name of your local Puppet Server role
+ROLE_NAME=''
+##############################################
+
+echo "===>>> Preparing the Puppet Server environment ..."
+cd /etc/puppetlabs/code/environments/
+rm -rf production/
+ln -s /vagrant/$CONTROL_REPO production
+
+echo "===>>> Provisioning Puppet Server ..."
+puppet apply -e "include $ROLE_NAME"
+
+echo "===>>> Applying Puppet agent ..."
+puppet agent -t || test $? -eq 2
+
+echo "===>>> Puppet Server ready to use!"
+echo "===>>> "
+echo "===>>> "
+echo "===>>> Enjoy!"
+echo "===>>> "


### PR DESCRIPTION
This change allows to configure the VMs after the Puppet agent
installation, but before the provision finish. A simple use case:
to automate the Puppet Server configuration to speed up a full
environment setup.