### PR TITLE
Add support to Windows 2016 box

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ nodes:
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box
   oracle-5:
     box: gutocarvalho/oracle5x64nocm
+  windows-2016:
+    memory: 2048
+    cpus: 2
+    type: windows
+    box: mwrock/Windows2016
 ```
 
 The `defaults` hash has keys that configure how VirtualBox and Vagrant will work and also values that configure the VMs specified in the `nodes` hash.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,6 +73,7 @@ Vagrant.configure('2') do |config|
         n.vm.hostname = node
         n.vm.communicator = 'winrm'
         n.vm.synced_folder '.', '/vagrant', disabled: true
+        n.vm.network 'forwarded_port', host: 3389, guest: 3389, auto_correct: true
         n.vm.provision 'shell' do |s|
           s.path = 'puppet-agent-installer.ps1'
           s.args = ['-PuppetVersion', puppet_agent_version]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,6 @@ Vagrant.configure('2') do |config|
         n.vm.hostname = node
         n.vm.communicator = 'winrm'
         n.vm.synced_folder '.', '/vagrant', disabled: true
-        n.vm.network 'forwarded_port', host: 3389, guest: 3389, auto_correct: true
         n.vm.provision 'shell' do |s|
           s.path = 'puppet-agent-installer.ps1'
           s.args = ['-PuppetVersion', puppet_agent_version]

--- a/environment.yaml
+++ b/environment.yaml
@@ -55,3 +55,8 @@ nodes:
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box
   oracle-5:
     box: gutocarvalho/oracle5x64nocm
+  windows-2016:
+    memory: 2048
+    cpus: 2
+    type: windows
+    box: mwrock/Windows2016


### PR DESCRIPTION
The RDP 3389 port was removed because the Windows boxes (2008, 2012 and 2016) already have it declared in the internal Vagrantfile's.