### PR TITLE
Fix Windows RDP port duplication

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -73,7 +73,8 @@ Vagrant.configure('2') do |config|
         n.vm.hostname = node
         n.vm.communicator = 'winrm'
         n.vm.synced_folder '.', '/vagrant', disabled: true
-        n.vm.network 'forwarded_port', host: 3389, guest: 3389, auto_correct: true
+        rdp_port = "338#{index + 10}"
+        n.vm.network 'forwarded_port', host: "#{rdp_port}", guest: 3389, auto_correct: true, id: 'rdp'
         n.vm.provision 'shell' do |s|
           s.path = 'puppet-agent-installer.ps1'
           s.args = ['-PuppetVersion', puppet_agent_version]


### PR DESCRIPTION
The Windows 2016 box already have the RDP port configured in the
internal Vagrantfile. This change fixes the Vagrant (> 2.0) error
for duplicate port forward declaration.

Each box will configure an unique host port based on it's index, starting in 33810.