### PR TITLE
Bump Vagrant required version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 
 require 'yaml'
 
-Vagrant.require_version '>= 1.9.2'
+Vagrant.require_version '>= 2.0.1'
 vagrant_root = File.dirname(__FILE__)
 
 required_plugins = ['vagrant-hosts']


### PR DESCRIPTION
The method `String#match?` was [introduced in ruby 2.4](https://bugs.ruby-lang.org/issues/12898).
This project's Vagrantfile uses the `match?` method to check the puppet agent version:
```
puppet_agent_version.match?(/\d\.\d{1,2}\.\d{1,2}/)
```
Vagrant [introduced ruby 2.4 in version 2.0.1](https://github.com/hashicorp/vagrant/blob/v2.0.1/CHANGELOG.md#201-november-2-2017).


This commit bumps the required vagrant version to ensure it won't crash when interpreting the Vagrantfile.