### PR TITLE
Fix #58; update Oracle Linux 7 box

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ nodes:
     box: opentable/win-2008r2-standard-amd64-nocm
   oracle-7:
     box: oracle/7
-    box_url: http://yum.oracle.com/boxes/oraclelinux/ol74/ol74.box
+    box_url: https://yum.oracle.com/boxes/oraclelinux/ol75/ol75.box
   oracle-6:
     box: oracle/6
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box

--- a/environment.yaml
+++ b/environment.yaml
@@ -52,7 +52,7 @@ nodes:
     box: opentable/win-2008r2-standard-amd64-nocm
   oracle-7:
     box: oracle/7
-    box_url: http://yum.oracle.com/boxes/oraclelinux/ol74/ol74.box
+    box_url: https://yum.oracle.com/boxes/oraclelinux/ol75/ol75.box
   oracle-6:
     box: oracle/6
     box_url: http://yum.oracle.com/boxes/oraclelinux/ol69/ol69.box


### PR DESCRIPTION
This change updates the Oracle Linux 7 URL to download the newest
Vagrant box available.