### PR TITLE
Fix #60; update default agent version 5.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ defaults:
   domain: 'dev'
   network_prefix: '172.22.0'
   synced_folder_type: 'nfs'
-  puppet_agent_version: '5.5.3'
+  puppet_agent_version: '5.5.4'
 nodes:
   puppet:
     memory: 2048

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ defaults:
   domain: 'dev'
   network_prefix: '172.22.0'
   synced_folder_type: 'nfs'
-  puppet_agent_version: '5.5.3'
+  puppet_agent_version: '5.5.4'
 nodes:
   puppet:
     memory: 2048


### PR DESCRIPTION
This changes updates the default Puppet agent version to 5.5.4, in all
operating systems that have the package available.