### PR TITLE
Fix #66; add support to Puppet agent 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ On the `nodes` hash there is the definition of the VMs that will be managed by V
 
 The `puppet` VM is the one that we use to setup Puppet Server and has more memory and CPUs than the other nodes, which will use the values from `defaults` if not specified.
 
+You can use Puppet agent from 4 to 6.
+
 ## Boxes
 
 We chose [Vagrant](https://www.vagrantup.com/) boxes that are as close as possible to a vanilla and minimal installation of the corresponding operating system. Better yet if the box is built and maintained by the vendor itself.

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ defaults:
   domain: 'dev'
   network_prefix: '172.22.0'
   synced_folder_type: 'nfs'
-  puppet_agent_version: '5.5.4'
+  puppet_agent_version: '5.5.4' # Supports Puppet version from 4 to 6
 nodes:
   puppet:
     memory: 2048

--- a/puppet-agent-installer.ps1
+++ b/puppet-agent-installer.ps1
@@ -29,11 +29,14 @@ param(
 )
 
 if ($PuppetVersion) {
-    $isPuppetFive = ($PuppetVersion[0] -eq '5')
-    if ($isPuppetFive) {
-        $MsiUrl = "https://downloads.puppet.com/windows/puppet5/puppet-agent-$($PuppetVersion)-x64.msi"
+    if ($PuppetVersion[0] -eq '6') {
+        $MsiUrl = "https://downloads.puppet.com/windows/puppet6/puppet-agent-$($PuppetVersion)-x64.msi"
     } else {
-        $MsiUrl = "https://downloads.puppet.com/windows/puppet-agent-$($PuppetVersion)-x64.msi"
+        if ($PuppetVersion[0] -eq '5') {
+            $MsiUrl = "https://downloads.puppet.com/windows/puppet5/puppet-agent-$($PuppetVersion)-x64.msi"
+        } else {
+            $MsiUrl = "https://downloads.puppet.com/windows/puppet-agent-$($PuppetVersion)-x64.msi"
+        }
     }
     Write-Output "Puppet version $PuppetVersion specified, updated MsiUrl to `"$MsiUrl`""
 }

--- a/puppet-agent-installer.sh
+++ b/puppet-agent-installer.sh
@@ -6,20 +6,19 @@ set -o pipefail
 
 PUPPET_AGENT_VERSION=$1
 
-if [[ ${PUPPET_AGENT_VERSION:0:1} == "5" ]] ; then
-  PUPPET_5=0 # true
-else
-  PUPPET_5=1 # false
-fi
-
 detect_rhel_or_oracle_7 ( ) {
 
   if grep -E ' 7\.' /etc/redhat-release &> /dev/null; then
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      yum install -y http://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm
-    else
-      yum install -y http://yum.puppet.com/puppetlabs-release-pc1-el-7.noarch.rpm
-    fi
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        yum install -y http://yum.puppet.com/puppet6/puppet6-release-el-7.noarch.rpm
+        ;;
+      5)
+        yum install -y http://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm
+        ;;
+      *)
+        yum install -y http://yum.puppet.com/puppetlabs-release-pc1-el-7.noarch.rpm
+    esac
     yum install -y "puppet-agent-${PUPPET_AGENT_VERSION}"
   fi
 
@@ -28,11 +27,16 @@ detect_rhel_or_oracle_7 ( ) {
 detect_rhel_or_oracle_6 ( ) {
 
   if grep -E ' 6\.' /etc/redhat-release &> /dev/null; then
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      yum install -y http://yum.puppet.com/puppet5/puppet5-release-el-6.noarch.rpm
-    else
-      yum install -y http://yum.puppet.com/puppetlabs-release-pc1-el-6.noarch.rpm
-    fi
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        yum install -y http://yum.puppet.com/puppet6/puppet6-release-el-6.noarch.rpm
+        ;;
+      5)
+        yum install -y http://yum.puppet.com/puppet5/puppet5-release-el-6.noarch.rpm
+        ;;
+      *)
+        yum install -y http://yum.puppet.com/puppetlabs-release-pc1-el-6.noarch.rpm
+    esac
     yum install -y "puppet-agent-${PUPPET_AGENT_VERSION}"
   fi
 
@@ -46,15 +50,22 @@ detect_rhel_or_oracle_5 ( ) {
       && rpm --import RPM-GPG-KEY-puppet \
       && rm -f RPM-GPG-KEY-puppet
 
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      curl -s -O http://yum.puppet.com/puppet5/puppet-release-el-5.noarch.rpm \
-        && yum install -y puppet-release-el-5.noarch.rpm \
-        && rm -f puppet-release-el-5.noarch.rpm
-    else
-      curl -s -O http://yum.puppet.com/puppetlabs-release-pc1-el-5.noarch.rpm \
-        && yum install -y puppetlabs-release-pc1-el-5.noarch.rpm \
-        && rm -f puppetlabs-release-pc1-el-5.noarch.rpm
-    fi
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        curl -s -O http://yum.puppet.com/puppet6/puppet-release-el-5.noarch.rpm \
+          && yum install -y puppet-release-el-5.noarch.rpm \
+          && rm -f puppet-release-el-5.noarch.rpm
+        ;;
+      5)
+        curl -s -O http://yum.puppet.com/puppet5/puppet-release-el-5.noarch.rpm \
+          && yum install -y puppet-release-el-5.noarch.rpm \
+          && rm -f puppet-release-el-5.noarch.rpm
+        ;;
+      *)
+        curl -s -O http://yum.puppet.com/puppetlabs-release-pc1-el-5.noarch.rpm \
+          && yum install -y puppetlabs-release-pc1-el-5.noarch.rpm \
+          && rm -f puppetlabs-release-pc1-el-5.noarch.rpm
+    esac
 
     yum install -y "puppet-agent-${PUPPET_AGENT_VERSION}"
   fi
@@ -65,9 +76,19 @@ detect_ubuntu_1804 ( ) {
 
   if grep -E 'DISTRIB_RELEASE=18.04' /etc/lsb-release &> /dev/null; then
     cd /tmp
-    curl -s -O http://apt.puppet.com/puppet5-release-bionic.deb
-    dpkg -i puppet5-release-bionic.deb
-    rm -f puppet5-release-bionic.deb
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        curl -s -O http://apt.puppet.com/puppet6-release-bionic.deb
+        dpkg -i puppet6-release-bionic.deb
+        rm -f puppet6-release-bionic.deb
+        ;;
+      *)
+        curl -s -O http://apt.puppet.com/puppet5-release-bionic.deb
+        dpkg -i puppet5-release-bionic.deb
+        rm -f puppet5-release-bionic.deb
+    esac
+
     apt-get update
     apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
   fi
@@ -78,15 +99,24 @@ detect_ubuntu_1604 ( ) {
 
   if grep -E 'DISTRIB_RELEASE=16.04' /etc/lsb-release &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      curl -s -O http://apt.puppet.com/puppet5-release-xenial.deb
-      dpkg -i puppet5-release-xenial.deb
-      rm -f puppet5-release-xenial.deb
-    else
-      curl -s -O http://apt.puppet.com/puppetlabs-release-pc1-xenial.deb
-      dpkg -i puppetlabs-release-pc1-xenial.deb
-      rm -f puppetlabs-release-pc1-xenial.deb
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        curl -s -O http://apt.puppet.com/puppet6-release-xenial.deb
+        dpkg -i puppet6-release-xenial.deb
+        rm -f puppet6-release-xenial.deb
+        ;;
+      5)
+        curl -s -O http://apt.puppet.com/puppet5-release-xenial.deb
+        dpkg -i puppet5-release-xenial.deb
+        rm -f puppet5-release-xenial.deb
+        ;;
+      *)
+        curl -s -O http://apt.puppet.com/puppetlabs-release-pc1-xenial.deb
+        dpkg -i puppetlabs-release-pc1-xenial.deb
+        rm -f puppetlabs-release-pc1-xenial.deb
+    esac
+
     apt-get update
     apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
   fi
@@ -97,15 +127,24 @@ detect_ubuntu_1404 ( ) {
 
   if grep -E 'DISTRIB_RELEASE=14.04' /etc/lsb-release &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      curl -s -O http://apt.puppet.com/puppet5-release-trusty.deb
-      dpkg -i puppet5-release-trusty.deb
-      rm -f puppet5-release-trusty.deb
-    else
-      curl -s -O http://apt.puppet.com/puppetlabs-release-pc1-trusty.deb
-      dpkg -i puppetlabs-release-pc1-trusty.deb
-      rm -f puppetlabs-release-pc1-trusty.deb
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        curl -s -O http://apt.puppet.com/puppet6-release-trusty.deb
+        dpkg -i puppet6-release-trusty.deb
+        rm -f puppet6-release-trusty.deb
+        ;;
+      5)
+        curl -s -O http://apt.puppet.com/puppet5-release-trusty.deb
+        dpkg -i puppet5-release-trusty.deb
+        rm -f puppet5-release-trusty.deb
+        ;;
+      *)
+        curl -s -O http://apt.puppet.com/puppetlabs-release-pc1-trusty.deb
+        dpkg -i puppetlabs-release-pc1-trusty.deb
+        rm -f puppetlabs-release-pc1-trusty.deb
+    esac
+
     apt-get update
     # Confirm because the box already comes with a puppet package installed
     apt-get install -y "puppet-agent=${PUPPET_AGENT_VERSION}*"
@@ -118,8 +157,8 @@ detect_ubuntu_1204 ( ) {
 
   if grep -E 'DISTRIB_RELEASE=12.04' /etc/lsb-release &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      echo '[Warning] There are no packages for Puppet 5 available! Installing the last one!'
+    if [[ ${PUPPET_AGENT_VERSION:0:1} -ne 1 ]] ; then
+      echo '[Warning] There are no packages for Puppet 5 or 6 available! Installing the last one!'
       PUPPET_AGENT_VERSION="1.10.0"
     fi
     curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-precise.deb
@@ -137,8 +176,8 @@ detect_debian_6 ( ) {
 
   if grep -E '^6\.[0-9]' /etc/debian_version &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      echo '[Warning] There are no packages for Puppet 5 available! Installing the last one!'
+    if [[ ${PUPPET_AGENT_VERSION:0:1} -ne 1 ]] ; then
+      echo '[Warning] There are no packages for Puppet 5 or 6 available! Installing the last one!'
       PUPPET_AGENT_VERSION="1.4.1"
     fi
     wget http://apt.puppetlabs.com/puppetlabs-release-pc1-squeeze.deb
@@ -154,15 +193,26 @@ detect_debian_7 ( ) {
 
   if grep -E '^7\.[0-9]' /etc/debian_version &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      wget http://apt.puppet.com/puppet5-release-wheezy.deb
-      dpkg -i puppet5-release-wheezy.deb
-      rm -f puppet5-release-wheezy.deb
-    else
-      wget http://apt.puppet.com/puppetlabs-release-pc1-wheezy.deb
-      dpkg -i puppetlabs-release-pc1-wheezy.deb
-      rm -f puppetlabs-release-pc1-wheezy.deb
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        echo '[Warning] There are no packages for Puppet 6 available! Installing the last one for 5!'
+        PUPPET_AGENT_VERSION="5.5.1"
+        wget http://apt.puppet.com/puppet5-release-wheezy.deb
+        dpkg -i puppet5-release-wheezy.deb
+        rm -f puppet5-release-wheezy.deb
+        ;;
+      5)
+        wget http://apt.puppet.com/puppet5-release-wheezy.deb
+        dpkg -i puppet5-release-wheezy.deb
+        rm -f puppet5-release-wheezy.deb
+        ;;
+      *)
+        wget http://apt.puppet.com/puppetlabs-release-pc1-wheezy.deb
+        dpkg -i puppetlabs-release-pc1-wheezy.deb
+        rm -f puppetlabs-release-pc1-wheezy.deb
+    esac
+
     apt-get update
     apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
   fi
@@ -173,15 +223,24 @@ detect_debian_8 ( ) {
 
   if grep -E '^8\.[0-9]' /etc/debian_version &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      wget http://apt.puppet.com/puppet5-release-jessie.deb
-      dpkg -i puppet5-release-jessie.deb
-      rm -f puppet5-release-jessie.deb
-    else
-      wget http://apt.puppet.com/puppetlabs-release-pc1-jessie.deb
-      dpkg -i puppetlabs-release-pc1-jessie.deb
-      rm -f puppetlabs-release-pc1-jessie.deb
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        wget http://apt.puppet.com/puppet6-release-jessie.deb
+        dpkg -i puppet6-release-jessie.deb
+        rm -f puppet6-release-jessie.deb
+        ;;
+      5)
+        wget http://apt.puppet.com/puppet5-release-jessie.deb
+        dpkg -i puppet5-release-jessie.deb
+        rm -f puppet5-release-jessie.deb
+        ;;
+      *)
+        wget http://apt.puppet.com/puppetlabs-release-pc1-jessie.deb
+        dpkg -i puppetlabs-release-pc1-jessie.deb
+        rm -f puppetlabs-release-pc1-jessie.deb
+    esac
+
     apt-get update
     apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
   fi
@@ -192,15 +251,24 @@ detect_debian_9 ( ) {
 
   if grep -E '^9\.[0-9]' /etc/debian_version &> /dev/null; then
     cd /tmp
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      wget http://apt.puppet.com/puppet5-release-stretch.deb
-      dpkg -i puppet5-release-stretch.deb
-      rm -f puppet5-release-stretch.deb
-    else
-      wget http://apt.puppet.com/puppetlabs-release-pc1-stretch.deb
-      dpkg -i puppetlabs-release-pc1-stretch.deb
-      rm -f puppetlabs-release-pc1-stretch.deb
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        wget http://apt.puppet.com/puppet6-release-stretch.deb
+        dpkg -i puppet6-release-stretch.deb
+        rm -f puppet6-release-stretch.deb
+        ;;
+      5)
+        wget http://apt.puppet.com/puppet5-release-stretch.deb
+        dpkg -i puppet5-release-stretch.deb
+        rm -f puppet5-release-stretch.deb
+        ;;
+      *)
+        wget http://apt.puppet.com/puppetlabs-release-pc1-stretch.deb
+        dpkg -i puppetlabs-release-pc1-stretch.deb
+        rm -f puppetlabs-release-pc1-stretch.deb
+    esac
+
     apt-get update
     apt-get install "puppet-agent=${PUPPET_AGENT_VERSION}*"
   fi
@@ -210,12 +278,22 @@ detect_debian_9 ( ) {
 detect_sles_12 ( ) {
 
   if grep -E 'VERSION="12-' /etc/os-release &> /dev/null; then
-    curl -s -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet \
-      && rpm --import RPM-GPG-KEY-puppet \
-      && rm -f RPM-GPG-KEY-puppet
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      zypper install --no-confirm http://yum.puppet.com/puppet5/puppet5-release-sles-12.noarch.rpm
-    fi
+    cd /tmp
+    curl -s -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+    rpm --import RPM-GPG-KEY-puppet
+    rm -f RPM-GPG-KEY-puppet
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        zypper install --no-confirm http://yum.puppet.com/puppet6/puppet6-release-sles-12.noarch.rpm
+        ;;
+      5)
+        zypper install --no-confirm http://yum.puppet.com/puppet5/puppet5-release-sles-12.noarch.rpm
+        ;;
+      *)
+        zypper install --no-confirm http://yum.puppet.com/puppetlabs-release-pc1-sles-12.noarch.rpm
+    esac
+
     zypper install --oldpackage --no-recommends --no-confirm "puppet-agent=${PUPPET_AGENT_VERSION}"
   fi
 
@@ -224,15 +302,23 @@ detect_sles_12 ( ) {
 detect_sles_11 ( ) {
 
   if grep -E 'VERSION_ID="11' /etc/os-release &> /dev/null; then
-    curl -s -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet \
-      && rpm --import RPM-GPG-KEY-puppet \
-      && rm -f RPM-GPG-KEY-puppet
+    cd /tmp
+    curl -s -O http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+    rpm --import RPM-GPG-KEY-puppet
+    rm -f RPM-GPG-KEY-puppet
     gem uninstall --all --executables facter hiera puppet
-    if [[ ${PUPPET_5} -eq 0 ]] ; then
-      zypper install --no-confirm http://yum.puppet.com/puppet5/puppet5-release-sles-11.noarch.rpm
-    else
-      zypper install --no-confirm http://yum.puppet.com/puppetlabs-release-pc1-sles-11.noarch.rpm
-    fi
+
+    case "${PUPPET_AGENT_VERSION:0:1}" in
+      6)
+        zypper install --no-confirm http://yum.puppet.com/puppet6/puppet6-release-sles-11.noarch.rpm
+        ;;
+      5)
+        zypper install --no-confirm http://yum.puppet.com/puppet5/puppet5-release-sles-11.noarch.rpm
+        ;;
+      *)
+        zypper install --no-confirm http://yum.puppet.com/puppetlabs-release-pc1-sles-11.noarch.rpm
+    esac
+
     zypper install --oldpackage --no-recommends --no-confirm "puppet-agent=${PUPPET_AGENT_VERSION}"
   fi
 


### PR DESCRIPTION
This changes add support to the Puppet agent 6 release, allowing this
version to be installed in the created VMs.

However, the release 6 is not the new default, because the MCollective
agent is not available anymore.